### PR TITLE
Fix non initialized matrix in Sturm.cpp

### DIFF
--- a/src/math/Sturm.cpp
+++ b/src/math/Sturm.cpp
@@ -142,6 +142,7 @@ opengv::math::Sturm::Sturm( const Eigen::MatrixXd & p ) :
 {
   _dimension = (size_t) _C.cols();
   _C = Eigen::MatrixXd(_dimension,_dimension);
+  _C.setZero();
   _C.row(0) = p;
 
   for( size_t i = 1; i < _dimension; i++ )
@@ -162,6 +163,7 @@ opengv::math::Sturm::Sturm( const std::vector<double> & p ) :
 {
   _dimension = (size_t) _C.cols();
   _C = Eigen::MatrixXd(_dimension,_dimension);
+  _C.setZero();
 
   for( size_t i = 0; i < _dimension; i++ )
     _C(0,i) = p[i];


### PR DESCRIPTION
Introduced to make valgrind stop complaining about use of uninitialized values when using five_pt_nister method. It should prevent potential segfault.